### PR TITLE
Ensure wheel is installed

### DIFF
--- a/image/Containerfile
+++ b/image/Containerfile
@@ -7,6 +7,7 @@ RUN microdnf -y install \
   golang \
   jq \
   krb5-devel \
+  python3-wheel \
   /usr/bin/pip \
   /usr/bin/poetry \
   /usr/bin/make \


### PR DESCRIPTION
I'm surprised this isn't pulled in automatically by any of the tox/pip/poetry packages. Noticed after seeing some logs mention:

    Using legacy 'setup.py install' for <pkg>, since package 'wheel' is not installed.