### PR TITLE
Install unzip

### DIFF
--- a/image/Containerfile
+++ b/image/Containerfile
@@ -9,6 +9,7 @@ RUN microdnf -y install \
   krb5-devel \
   python3-wheel \
   libffi-devel \
+  unzip \
   /usr/bin/gpg \
   /usr/bin/pip \
   /usr/bin/poetry \


### PR DESCRIPTION
The image build fails on "/bin/sh: line 1: unzip: command not found". Installing the "unzip" package resolves this error.